### PR TITLE
Clarify network related variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Then perform the following commands on the config folder:
 | forseti\_run\_frequency | Schedule of running the Forseti scans | string | `* */2 * * *` | no |
 | forseti\_version | Forseti software revision that you want | string | `stable` | no |
 | gsuite\_admin\_email | G-Suite administrator email address to manage your Forseti installation | string | - | yes |
+| network | The VPC where the Forseti client and server will be created | string | `default` | no |
+| network\_project | The project containing the VPC and subnetwork where the Forseti client and server will be created | string | `` | no |
 | org\_id | GCP Organization ID that Forseti will have purview over | string | `` | no |
 | project\_id | Google Project ID that you want Forseti deployed into | string | - | yes |
 | sendgrid\_api\_key | Sendgrid.com API key to enable email notifications | string | `` | no |
@@ -56,9 +58,8 @@ Then perform the following commands on the config folder:
 | server\_region | GCP region where Forseti will be deployed | string | `us-central1` | no |
 | server\_type | GCE Forseti Server role instance size | string | `n1-standard-2` | no |
 | storage\_bucket\_location | GCS storage bucket location | string | `us-central1` | no |
-| vpc\_host\_network | VPC host network | string | `default` | no |
-| vpc\_host\_project\_id | Shared VPC host project | string | `` | no |
-| vpc\_host\_subnetwork | VPC subnetwork | string | `default` | no |
+| subnetwork | The VPC subnetwork where the Forseti client and server will be created | string | `default` | no |
+
 ## Outputs
 
 | Name | Description |

--- a/client.tf
+++ b/client.tf
@@ -64,8 +64,8 @@ resource "google_compute_instance" "forseti-client" {
   }
 
   network_interface {
-    subnetwork_project = "${local.vpc_host_project_id}"
-    subnetwork         = "${var.vpc_host_subnetwork}"
+    subnetwork_project = "${local.network_project}"
+    subnetwork         = "${var.subnetwork}"
 
     access_config {}
   }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -24,6 +24,6 @@ module "forseti-install-simple" {
   gsuite_admin_email  = "${var.gsuite_admin_email}"
   org_id              = "${var.org_id}"
   server_type         = "n1-standard-4"
-  vpc_host_subnetwork = "${var.vpc_host_subnetwork}"
+  subnetwork          = "${var.subnetwork}"
   enable_cai_bucket   = "${var.enable_cai_bucket}"
 }

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -30,7 +30,7 @@ variable "org_id" {
   description = "The organization id"
 }
 
-variable "vpc_host_subnetwork" {
+variable "subnetwork" {
   default = "default"
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -27,7 +27,7 @@ resource "random_id" "random_hash_suffix" {
 locals {
   random_hash             = "${random_id.random_hash_suffix.hex}"
   root_resource_id        = "${var.org_id != "" ? "organizations/${var.org_id}" : var.folder_id != "" ? "folders/${var.folder_id}" : ""}"
-  vpc_host_project_id     = "${var.vpc_host_project_id}"
+  network_project         = "${var.network_project != "" ? var.network_project : var.project_id}"
   server_zone             = "${var.server_region}-c"
   server_startup_script   = "${file("${path.module}/scripts/forseti-server/forseti_server_startup_script.sh.tpl")}"
   server_environment      = "${file("${path.module}/scripts/forseti-server/forseti_environment.sh.tpl")}"

--- a/server.tf
+++ b/server.tf
@@ -127,8 +127,8 @@ resource "google_organization_iam_member" "folder_write" {
 #------------------------#
 resource "google_compute_firewall" "forseti-server-deny-all" {
   name                    = "forseti-server-deny-all-${local.random_hash}"
-  project                 = "${local.vpc_host_project_id}"
-  network                 = "${var.vpc_host_network}"
+  project                 = "${local.network_project}"
+  network                 = "${var.network}"
   target_service_accounts = ["${google_service_account.forseti_server.email}"]
   source_ranges           = ["0.0.0.0/0"]
   priority                = "200"
@@ -148,8 +148,8 @@ resource "google_compute_firewall" "forseti-server-deny-all" {
 
 resource "google_compute_firewall" "forseti-server-ssh-external" {
   name                    = "forseti-server-ssh-external-${local.random_hash}"
-  project                 = "${var.project_id}"
-  network                 = "${var.vpc_host_network}"
+  project                 = "${local.network_project}"
+  network                 = "${var.network}"
   target_service_accounts = ["${google_service_account.forseti_server.email}"]
   source_ranges           = ["0.0.0.0/0"]
   priority                = "100"
@@ -162,8 +162,8 @@ resource "google_compute_firewall" "forseti-server-ssh-external" {
 
 resource "google_compute_firewall" "forseti-server-allow-grpc" {
   name                    = "forseti-server-allow-grpc-${local.random_hash}"
-  project                 = "${var.project_id}"
-  network                 = "${var.vpc_host_network}"
+  project                 = "${local.network_project}"
+  network                 = "${var.network}"
   target_service_accounts = ["${google_service_account.forseti_server.email}"]
   source_ranges           = ["10.128.0.0/9"]
   priority                = "100"
@@ -226,8 +226,8 @@ resource "google_compute_instance" "forseti-server" {
   }
 
   network_interface {
-    subnetwork_project = "${var.project_id}"
-    subnetwork         = "${var.vpc_host_subnetwork}"
+    subnetwork_project = "${local.network_project}"
+    subnetwork         = "${var.subnetwork}"
 
     access_config {}
   }

--- a/test/fixtures/tf_module/main.tf
+++ b/test/fixtures/tf_module/main.tf
@@ -24,6 +24,6 @@ module "forseti-install-simple" {
   gsuite_admin_email  = "${var.gsuite_admin_email}"
   org_id              = "${var.org_id}"
   server_type         = "n1-standard-4"
-  vpc_host_subnetwork = "${var.vpc_host_subnetwork}"
+  network_project     = "${var.network_project}"
   enable_cai_bucket   = "${var.enable_cai_bucket}"
 }

--- a/test/fixtures/tf_module/variables.tf
+++ b/test/fixtures/tf_module/variables.tf
@@ -30,8 +30,8 @@ variable "org_id" {
   description = "The organization id"
 }
 
-variable "vpc_host_subnetwork" {
-  default = "default"
+variable "network_project" {
+  default = ""
 }
 
 variable "enable_cai_bucket" {

--- a/variables.tf
+++ b/variables.tf
@@ -140,18 +140,18 @@ variable "bucket_cai_lifecycle_age" {
 #---------#
 # Network #
 #---------#
-variable "vpc_host_network" {
-  description = "VPC host network"
+variable "network" {
+  description = "The VPC where the Forseti client and server will be created"
   default     = "default"
 }
 
-variable "vpc_host_subnetwork" {
-  description = "VPC subnetwork"
+variable "subnetwork" {
+  description = "The VPC subnetwork where the Forseti client and server will be created"
   default     = "default"
 }
 
-variable "vpc_host_project_id" {
-  description = "Shared VPC host project"
+variable "network_project" {
+  description = "The project containing the VPC and subnetwork where the Forseti client and server will be created"
   default     = ""
 }
 


### PR DESCRIPTION
The variables controlling where GCP instances and firewall rules were
created were ambiguous, making it unclear where a separate VPC and
project were used or required. This commit changes the names to match
the variables used by `google_compute_instance` and
`google_compute_firewall`, and adds `project_id` as a default value for
the `subnetwork_project` variable.